### PR TITLE
fix: 퇴근 상태 저장 로직 추가 작성

### DIFF
--- a/src/main/java/com/example/shiftmate/domain/attendance/entity/Attendance.java
+++ b/src/main/java/com/example/shiftmate/domain/attendance/entity/Attendance.java
@@ -41,4 +41,8 @@ public class Attendance extends BaseTimeEntity {
     public void clockOut(LocalDateTime time) {
         this.clockOutAt = time;
     }
+
+    public void changeStatus(AttendanceStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/example/shiftmate/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/example/shiftmate/domain/attendance/service/AttendanceService.java
@@ -101,6 +101,7 @@ public class AttendanceService {
         AttendanceStatus status = AttendanceStatus.OFFWORK;
         String message = "퇴근 처리되었습니다.";
         attendance.clockOut(now);
+        attendance.changeStatus(status);
 
         return AttendanceResDto.builder()
                 .attendanceId(attendance.getId())


### PR DESCRIPTION
## 수정 사항
일일 근태 조회를 했을 때 퇴근 처리를 해서 퇴근 시간까지 조회가 되는 스케줄의 status가 NORMAL 또는 LATE만 뜨는 문제가 있었습니다. (퇴근을 하면 status가 OFFWORK로 떠야합니다)

퇴근 처리 로직에서 clockOut만 저장하고, status는 OFFWORK로 변경은 했으나 저장하는 로직을 작성하지 않아서 발생하는 문제였습니다.
changeStatus 메서드를 작성해서 퇴근 처리 시 status도 OFFWORK로 저장되도록 수정했습니다.

## 테스트
수정 후 테스트하여 퇴근 처리된 스케줄은 status가 OFFWORK로 뜨는 것 확인했습니다.
<img width="1387" height="818" alt="offwork 수정 반영" src="https://github.com/user-attachments/assets/2061d5a5-475c-460f-b25b-fdacb5cef26f" />
