### PR TITLE
token 파싱 방식 수정

### DIFF
--- a/src/main/java/com/example/shiftmate/global/security/JwtFilter.java
+++ b/src/main/java/com/example/shiftmate/global/security/JwtFilter.java
@@ -34,15 +34,15 @@ public class JwtFilter extends OncePerRequestFilter {
 
         // 토큰이 있으면 유효성 검사 후 인증 처리
         if (StringUtils.hasText(token)) {
-            // 유효하지 않으면 예외 발생
-            jwtProvider.validateToken(token);
+            // 유효하지 않으면 예외 발생 + Claims 한번만 파싱
+            io.jsonwebtoken.Claims claims = jwtProvider.parseClaims(token);
 
             // access 토큰인지 확인 (refresh면 인증 처리 안 함)
-            String category = jwtProvider.getCategory(token);
+            String category = claims.get("category", String.class);
             if (TOKEN_TYPE_ACCESS.equals(category)) {
 
                 // 토큰에서 이메일 추출 후 사용자 로딩
-                String email = jwtProvider.getEmail(token);
+                String email = claims.get("email", String.class);
                 UserDetails userDetails = userDetailsService.loadUserByUsername(email);
 
                 // 인증 객체를 SecurityContext에 등록

--- a/src/main/java/com/example/shiftmate/global/security/JwtProvider.java
+++ b/src/main/java/com/example/shiftmate/global/security/JwtProvider.java
@@ -73,8 +73,13 @@ public class JwtProvider {
 
     // 토큰 유효성 검사 (서명/만료 체크)
     public void validateToken(String token) {
+        parseClaims(token);
+    }
+
+    // 토큰을 파싱하여 Claims 반환 (예외는 CustomException으로 변환)
+    public Claims parseClaims(String token) {
         try {
-            Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+            return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
         } catch (SecurityException e) {
             throw new CustomException(ErrorCode.INVALID_SIGNATURE);
         } catch (MalformedJwtException e) {
@@ -86,11 +91,10 @@ public class JwtProvider {
         } catch (IllegalArgumentException e) {
             throw new CustomException(ErrorCode.EMPTY_TOKEN);
         }
-
     }
 
-    // 공통 Claims 파싱
-    private io.jsonwebtoken.Claims getClaims(String token) {
-        return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+    // 공통 Claims 파싱 (기존 메서드 유지)
+    private Claims getClaims(String token) {
+        return parseClaims(token);
     }
 }


### PR DESCRIPTION
getCategory, getEmail, getUserId 메소드는 호출될 때마다 토큰을 파싱하고 검증하는 getClaims를 내부적으로 호출합니다.

(*getCategory: access인지 refresh인지 구분 하는 용도)

JwtFilter나 AuthService에서 이 메소드들을 연달아 호출하면 동일한 토큰에 대해 여러 번 파싱이 일어나 비효율적입니다.

토큰을 한 번만 파싱하여 Claims 객체를 반환하는 public 메소드를 만들고, 다른 곳에서는 이 Claims 객체를 받아서 필요한 정보를 추출해 사용하도록 리팩토링함