### PR TITLE
fix: CORS/보안 설정 보강 및 Redis 장애 시 인증 흐름 개선

### DIFF
--- a/src/main/java/com/example/shiftmate/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/shiftmate/domain/auth/service/RefreshTokenService.java
@@ -1,18 +1,25 @@
 package com.example.shiftmate.domain.auth.service;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 // Refresh Token을 Redis에 저장/검증/삭제하는 서비스
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class RefreshTokenService {
 
     // Redis 키 prefix: refresh:email 형태로 저장
     private static final String REFRESH_PREFIX = "refresh:";
+    private static final Map<String, FallbackToken> FALLBACK_STORE = new ConcurrentHashMap<>();
 
     private final StringRedisTemplate redisTemplate;
 
@@ -20,27 +27,72 @@ public class RefreshTokenService {
     @Value("${jwt.refresh-expiration}")
     private long refreshExpiration;
 
+    // Redis 장애 시 메모리 fallback 사용 여부 (개발 환경 대응)
+    @Value("${auth.refresh.fallback-memory-enabled:true}")
+    private boolean fallbackMemoryEnabled;
+
     // refresh 토큰 저장 (email 기준 1개만 유지)
     // 동일 이메일로 재로그인 시 기존 토큰은 덮어씀
     public void save(String email, String refreshToken) {
         String key = REFRESH_PREFIX + email;
-        redisTemplate.opsForValue()
-            .set(key, refreshToken, Duration.ofMillis(refreshExpiration));
+        try {
+            redisTemplate.opsForValue()
+                .set(key, refreshToken, Duration.ofMillis(refreshExpiration));
+            FALLBACK_STORE.remove(key);
+        } catch (DataAccessException e) {
+            if (!fallbackMemoryEnabled) {
+                throw e;
+            }
+            log.warn("Redis unavailable. Fallback memory store is used for key={}", key);
+            FALLBACK_STORE.put(key, new FallbackToken(
+                refreshToken,
+                Instant.now().plusMillis(refreshExpiration)
+            ));
+        }
     }
 
     // 저장된 refresh 토큰 조회
     public String get(String email) {
-        return redisTemplate.opsForValue().get(REFRESH_PREFIX + email);
+        String key = REFRESH_PREFIX + email;
+        try {
+            return redisTemplate.opsForValue().get(key);
+        } catch (DataAccessException e) {
+            if (!fallbackMemoryEnabled) {
+                throw e;
+            }
+            FallbackToken token = FALLBACK_STORE.get(key);
+            if (token == null) {
+                return null;
+            }
+            if (token.expiredAt().isBefore(Instant.now())) {
+                FALLBACK_STORE.remove(key);
+                return null;
+            }
+            return token.value();
+        }
     }
 
     // 저장된 refresh 토큰 삭제 (로그아웃/강제 만료 처리)
     public void delete(String email) {
-        redisTemplate.delete(REFRESH_PREFIX + email);
+        String key = REFRESH_PREFIX + email;
+        try {
+            redisTemplate.delete(key);
+        } catch (DataAccessException e) {
+            if (!fallbackMemoryEnabled) {
+                throw e;
+            }
+            log.warn("Redis unavailable. Fallback memory delete is used for key={}", key);
+        } finally {
+            FALLBACK_STORE.remove(key);
+        }
     }
 
     // 전달된 refresh 토큰이 Redis에 저장된 값과 일치하는지 확인
     public boolean matches(String email, String refreshToken) {
         String saved = get(email);
         return saved != null && saved.equals(refreshToken);
+    }
+
+    private record FallbackToken(String value, Instant expiredAt) {
     }
 }

--- a/src/main/java/com/example/shiftmate/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/shiftmate/global/config/SecurityConfig.java
@@ -1,12 +1,19 @@
 package com.example.shiftmate.global.config;
 
 import com.example.shiftmate.global.security.JwtFilter;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -18,6 +25,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
+    @Value("${cors.allowed-origins:http://localhost:5173,http://localhost:3000}")
+    private String allowedOrigins;
 
     // 비밀번호 암호화 Bean
     @Bean
@@ -29,10 +38,12 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/auth/**").permitAll()
                         .anyRequest().permitAll()
                 )
@@ -40,5 +51,30 @@ public class SecurityConfig {
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        List<String> origins = Arrays.stream(allowedOrigins.split(","))
+            .map(String::trim)
+            .filter(origin -> !origin.isEmpty())
+            .toList();
+
+        configuration.setAllowedOrigins(origins);
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of(
+            "Content-Type",
+            "Authorization",
+            "Accept",
+            "Origin",
+            "X-Requested-With"
+        ));
+        configuration.setAllowCredentials(true);
+        configuration.setExposedHeaders(List.of("Authorization"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/example/shiftmate/global/security/JwtFilter.java
+++ b/src/main/java/com/example/shiftmate/global/security/JwtFilter.java
@@ -1,5 +1,7 @@
 package com.example.shiftmate.global.security;
 
+import com.example.shiftmate.global.common.dto.ApiError;
+import com.example.shiftmate.global.common.dto.ApiResponse;
 import com.example.shiftmate.global.exception.CustomException;
 import com.example.shiftmate.global.exception.ErrorCode;
 import jakarta.servlet.FilterChain;
@@ -7,7 +9,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -30,44 +35,79 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
+        try {
+            // Authorization 헤더에서 토큰 추출
+            String token = resolveToken(request);
 
-        // Authorization 헤더에서 토큰 추출
-        String token = resolveToken(request);
+            // 토큰이 있으면 유효성 검사 후 인증 처리
+            if (StringUtils.hasText(token)) {
+                // 유효하지 않으면 예외 발생 + Claims 한번만 파싱
+                io.jsonwebtoken.Claims claims = jwtProvider.parseClaims(token);
 
-        // 토큰이 있으면 유효성 검사 후 인증 처리
-        if (StringUtils.hasText(token)) {
-            // 유효하지 않으면 예외 발생 + Claims 한번만 파싱
-            io.jsonwebtoken.Claims claims = jwtProvider.parseClaims(token);
+                // access 토큰인지 확인 (refresh면 인증 처리 안 함)
+                String category = claims.get("category", String.class);
+                if (TOKEN_TYPE_ACCESS.equals(category)) {
 
-            // access 토큰인지 확인 (refresh면 인증 처리 안 함)
-            String category = claims.get("category", String.class);
-            if (TOKEN_TYPE_ACCESS.equals(category)) {
+                    // 토큰에서 이메일 추출 후 사용자 로딩
+                    String email = claims.get("email", String.class);
+                    if (email == null) {
+                        throw new CustomException(ErrorCode.MALFORMED_TOKEN);
+                    }
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(email);
 
-                // 토큰에서 이메일 추출 후 사용자 로딩
-                String email = claims.get("email", String.class);
-                if (email == null) {
-                    throw new CustomException(ErrorCode.MALFORMED_TOKEN);
+                    // 인증 객체를 SecurityContext에 등록
+                    UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, null,
+                            userDetails.getAuthorities());
+
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
-                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-
-                // 인증 객체를 SecurityContext에 등록
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-
-                SecurityContextHolder.getContext().setAuthentication(authentication);
             }
-        }
 
-        // 다음 필터로 넘김
-        filterChain.doFilter(request, response);
+            // 다음 필터로 넘김
+            filterChain.doFilter(request, response);
+        } catch (CustomException e) {
+            writeErrorResponse(response, e.getErrorCode());
+        }
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return HttpMethod.OPTIONS.matches(request.getMethod()) || path.startsWith("/auth");
     }
 
     // Authorization 헤더에서 Bearer 토큰만 추출
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-            return bearerToken.substring(7);
+            String token = bearerToken.substring(BEARER_PREFIX.length()).trim();
+            if (!StringUtils.hasText(token) || token.startsWith(BEARER_PREFIX)
+                || (token.startsWith("\"") && token.endsWith("\""))) {
+                throw new CustomException(ErrorCode.MALFORMED_TOKEN);
+            }
+            return token;
         }
         return null;
+    }
+
+    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode)
+        throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        ApiResponse<?> body = ApiResponse.error(ApiError.of(errorCode));
+        String json = "{\"success\":" + body.isSuccess()
+            + ",\"data\":null"
+            + ",\"error\":{\"code\":\"" + escapeJson(body.getError().getCode())
+            + "\",\"message\":\"" + escapeJson(body.getError().getMessage())
+            + "\",\"details\":[]}}";
+        response.getWriter().write(json);
+    }
+
+    private String escapeJson(String value) {
+        return value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"");
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,11 +14,12 @@ jwt.refresh-expiration=${JWT_REFRESH_EXPIRATION:604800000}
 jwt.secret=${JWT_SECRET}
 
 # Redis host and port settings
-spring.data.redis.host=redis
-spring.data.redis.port=6379
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.timeout=${REDIS_TIMEOUT:2s}
 
 # (Optional) Redis password configuration
 # spring.data.redis.password=your_password
 
 # CORS setting
-cors.allowed-origins=http://localhost:5173
+cors.allowed-origins=http://localhost:5173,http://localhost:3000


### PR DESCRIPTION
**배경**
- 프론트에서 `/auth/login` 요청 시 응답이 없거나 500이 발생하는 이슈가 있었습니다.
- 원인:
  1. CORS 설정 미흡(`localhost:3000` 미허용, preflight 대응 부족)
  2. JWT 필터가 인증 불필요 엔드포인트(`/auth/**`)까지 개입
  3. 잘못된 Authorization 헤더 형식 처리 시 500으로 전파
  4. Redis 연결 실패 시 refresh token 저장 단계에서 로그인 전체 실패

**주요 변경 사항**
- CORS/Security 설정 보강
  - `http.cors(...)` 활성화
  - `OPTIONS /**` 명시적 `permitAll`
  - `/auth/**` `permitAll` 유지
  - 허용 Origin에 `http://localhost:3000` 추가
  - 허용 헤더 명시: `Content-Type`, `Authorization`, `Accept`, `Origin`, `X-Requested-With`
- JWT 필터 안정화
  - `/auth/**`, `OPTIONS` 요청은 JWT 필터 스킵
  - Authorization 형식 검증 강화:
    - `Bearer <JWT>` 외 형식(`Bearer Bearer ...`, 빈 토큰, quoted token) 차단
  - 토큰 파싱/형식 오류 시 필터에서 직접 JSON 에러 응답(500 방지)
- Redis 의존성 완화(개발 환경)
  - Redis 연결 실패 시 refresh token 저장/조회/삭제를 메모리 fallback으로 처리
  - TTL 유지
  - 설정값: `auth.refresh.fallback-memory-enabled` (기본 `true`)
- Redis 설정 유연화
  - `REDIS_HOST`, `REDIS_PORT`, `REDIS_TIMEOUT` 환경변수 기반으로 변경

**수정 파일**
- `/Users/mac/Desktop/sesac/SeSAC_ShiftMate/ShiftMate_Back/src/main/java/com/example/shiftmate/global/config/SecurityConfig.java`
- `/Users/mac/Desktop/sesac/SeSAC_ShiftMate/ShiftMate_Back/src/main/java/com/example/shiftmate/global/security/JwtFilter.java`
- `/Users/mac/Desktop/sesac/SeSAC_ShiftMate/ShiftMate_Back/src/main/java/com/example/shiftmate/domain/auth/service/RefreshTokenService.java`
- `/Users/mac/Desktop/sesac/SeSAC_ShiftMate/ShiftMate_Back/src/main/resources/application.properties`

**검증**
- `./gradlew -q compileJava` 성공
- 기대 동작:
  - `/auth/login`은 Authorization 헤더 이상 유무와 무관하게 JWT 필터로 인해 실패하지 않음
  - Redis 다운 상태에서도 로그인 성공(메모리 fallback 경로)
  - CORS preflight(`OPTIONS`) 정상 통과

**리스크/주의사항**
- 메모리 fallback은 인스턴스 재시작 시 토큰 유실 가능(개발 편의용)
- 운영 환경에서는 Redis 정상 구성 + `auth.refresh.fallback-memory-enabled=false` 권장

**체크리스트**
- [x] 로그인 500 재현 케이스 대응
- [x] CORS/preflight 대응
- [x] JWT 필터 예외 전파 개선
- [x] 컴파일 검증 완료